### PR TITLE
Fix exz80all failures: DAA parity, CPI/CPD X/Y flags

### DIFF
--- a/rtl/core/tv80_alu.v
+++ b/rtl/core/tv80_alu.v
@@ -272,7 +272,7 @@ module tv80_alu (/*AUTOARG*/
 	      end
             
 	    F_Out[Flag_S] = DAA_Q[7];
-	    F_Out[Flag_P] = ~ (^DAA_Q);
+	    F_Out[Flag_P] = ~ (^DAA_Q[7:0]);
           end // case: 4'b1100
         
 	4'b1101, 4'b1110 :

--- a/rtl/core/tv80_core.v
+++ b/rtl/core/tv80_core.v
@@ -155,6 +155,9 @@ module tv80_core (/*AUTOARG*/
   wire [7:0]    ALU_Q;
   wire [7:0]    F_Out;
 
+  // Block-compare X/Y helper: CPI/CPD/CPIR/CPDR
+  wire [7:0]    cpi_xy_n = ALU_Q - {7'b0, F_Out[Flag_H]};
+
   // Registered micro code outputs
   reg [4:0]     Read_To_Reg_r;
   reg           Arith16_r;
@@ -839,14 +842,19 @@ module tv80_core (/*AUTOARG*/
                     end
                 end
 
-              if (tstate[1] && I_BT == 1'b1 ) 
+              if (tstate[1] && I_BT == 1'b1 )
                 begin
                   F[Flag_X] <= `TV80DELAY ALU_Q[3];
                   F[Flag_Y] <= `TV80DELAY ALU_Q[1];
                   F[Flag_H] <= `TV80DELAY 1'b0;
                   F[Flag_N] <= `TV80DELAY 1'b0;
                 end
-              if (I_BC == 1'b1 || I_BT == 1'b1 ) 
+              if (tstate[1] && I_BC == 1'b1 )
+                begin
+                  F[Flag_X] <= `TV80DELAY cpi_xy_n[3];
+                  F[Flag_Y] <= `TV80DELAY cpi_xy_n[1];
+                end
+              if (I_BC == 1'b1 || I_BT == 1'b1 )
                 begin
                   F[Flag_P] <= `TV80DELAY IncDecZ;
                 end


### PR DESCRIPTION
Fix three exz80all failures: DAA parity + CPI/CPD X/Y flags, resolves #5.

SIMH/AltairZ80’s [exz80all](https://schorn.ch/cpm/zip/cpm2.zip) reports CRC mismatches on three tests on the unmodified TV80:

 cpd<r>........... ERROR crc expected:4adf8a42 found:476624c0
 cpi<r>........... ERROR crc expected:d6257aa3 found:d24e3af0
 <daa,cpl,scf,ccf> ERROR crc expected:6d2dd213 found:204590f8

Two distinct bugs caused all three failures.

1. tv80_alu.v: DAA parity over the wrong bit-width:

DAA_Q is a 9-bit accumulator -- bit 8 holds the +0x60 / -0x160 carry-out used to drive the C flag. The parity flag was being computed via `~(^DAA_Q)`, which XOR-reduces all 9 bits, so any DAA that crosses the 0xFF boundary (any +0x60 add overflow, any sub that wraps through 0x100) gets P inverted vs the documented Z80 behaviour. Cross-checked against s100box's sim-z80 sz53p(), which XORs only over the 8-bit result. Fixed by reducing over `DAA_Q[7:0]`.

2. tv80_core.v: CPI/CPD X/Y flags use plain-CP rule
The ALU's CP case sets `F[X]=BusB[3]`, `F[Y]=BusB[5]` (operand bits) -- correct for plain `CP A,r`. CPI/CPD/CPIR/CPDR follow a different rule:
```
        n  = A - (HL) - H_after
        F3 = n[3], F5 = n[1]    (bit 1, not bit 5)
```
(Sean Young, "[The Undocumented Z80 Documented](http://www.z80.info/zip/z80-documented.pdf)", section 4.2.)

The block-transfer family I_BT already had an X/Y override at the tstate[1] block (line 842-848) using ALU_Q. The block-compare family I_BC was missing the equivalent override and was inheriting the operand-bits-3/5 rule from the standard CP path. Added a parallel `if (tstate[1] && I_BC == 1'b1)` block that pulls X/Y from `cpi_xy_n = ALU_Q - {7'b0, F_Out[Flag_H]}`.

Verification: run exz80all:

```
A>exz80all
Z80 instruction exerciser
Undefined status bits taken into account
<adc,sbc> hl,<bc,de,hl,sp>....( 71,680) cycles   OK
add hl,<bc,de,hl,sp>..........( 35,840) cycles   OK
add ix,<bc,de,ix,sp>..........( 35,840) cycles   OK
add iy,<bc,de,iy,sp>..........( 35,840) cycles   OK
aluop a,nn....................( 45,056) cycles   OK
aluop a,<b,c,d,e,h,l,(hl),a>..(753,664) cycles   OK
aluop a,<ixh,ixl,iyh,iyl>.....(376,832) cycles   OK
aluop a,(<ix,iy>+1)...........(229,376) cycles   OK
aluop a,(<ix,iy>-1)...........(229,376) cycles   OK
bit n,(<ix,iy>+1).............(  2,048) cycles   OK
bit n,(<ix,iy>-1).............(  2,048) cycles   OK
bit n,<b,c,d,e,h,l,(hl),a>....( 49,152) cycles   OK
cpd<r>........................(  6,144) cycles   OK
cpi<r>........................(  6,144) cycles   OK
<daa,cpl,scf,ccf>.............( 65,536) cycles   OK
<inc,dec> a...................(  3,072) cycles   OK
<inc,dec> b...................(  3,072) cycles   OK
<inc,dec> bc..................(  1,536) cycles   OK
<inc,dec> c...................(  3,072) cycles   OK
<inc,dec> d...................(  3,072) cycles   OK
<inc,dec> de..................(  1,536) cycles   OK
<inc,dec> e...................(  3,072) cycles   OK
<inc,dec> h...................(  3,072) cycles   OK
<inc,dec> hl..................(  1,536) cycles   OK
<inc,dec> ix..................(  1,536) cycles   OK
<inc,dec> iy..................(  1,536) cycles   OK
<inc,dec> l...................(  3,072) cycles   OK
<inc,dec> (hl)................(  3,072) cycles   OK
<inc,dec> sp..................(  1,536) cycles   OK
<inc,dec> (<ix,iy>+1).........(  6,144) cycles   OK
<inc,dec> (<ix,iy>-1).........(  6,144) cycles   OK
<inc,dec> ixh.................(  3,072) cycles   OK
<inc,dec> ixl.................(  3,072) cycles   OK
<inc,dec> iyh.................(  3,072) cycles   OK
<inc,dec> iyl.................(  3,072) cycles   OK
<ini,outi,ind,outd><,r>.......( 65,536) cycles   ERROR **** crc expected:47fff448 found:e3b0d5e0
ld <bc,de>,(nnnn).............(     32) cycles   OK
ld hl,(nnnn)..................(     16) cycles   OK
ld sp,(nnnn)..................(     16) cycles   OK
ld <ix,iy>,(nnnn).............(     32) cycles   OK
ld (nnnn),<bc,de>.............(     64) cycles   OK
ld (nnnn),hl..................(     16) cycles   OK
ld (nnnn),sp..................(     16) cycles   OK
ld (nnnn),<ix,iy>.............(     64) cycles   OK
ld <bc,de,hl,sp>,nnnn.........(     64) cycles   OK
ld <ix,iy>,nnnn...............(     32) cycles   OK
ld a,<(bc),(de)>..............(     44) cycles   OK
ld <b,c,d,e,h,l,(hl),a>,nn....(     64) cycles   OK
ld (<ix,iy>+1),nn.............(     32) cycles   OK
ld (<ix,iy>-1),nn.............(     32) cycles   OK
ld <b,c,d,e>,(<ix,iy>+1)......(    512) cycles   OK
ld <b,c,d,e>,(<ix,iy>-1)......(    512) cycles   OK
ld <h,l>,(<ix,iy>+1)..........(    256) cycles   OK
ld <h,l>,(<ix,iy>-1)..........(    256) cycles   OK
ld a,(<ix,iy>+1)..............(    128) cycles   OK
ld a,(<ix,iy>-1)..............(    128) cycles   OK
ld <ixh,ixl,iyh,iyl>,nn.......(     32) cycles   OK
ld <bcdehla>,<bcdehla>........(  3,456) cycles   OK
ld <bcdexya>,<bcdexya>........(  6,912) cycles   OK
ld a,(nnnn) / ld (nnnn),a.....(     44) cycles   OK
ldd<r> (1)....................(     44) cycles   OK
ldd<r> (2)....................(     44) cycles   OK
ldi<r> (1)....................(     44) cycles   OK
ldi<r> (2)....................(     44) cycles   OK
neg...........................( 16,384) cycles   OK
<rrd,rld>.....................(  7,168) cycles   OK
<rlca,rrca,rla,rra>...........(  6,144) cycles   OK
shf/rot (<ix,iy>+1)...........(    416) cycles   OK
shf/rot (<ix,iy>-1)...........(    416) cycles   OK
shf/rot <b,c,d,e,h,l,(hl),a>..(  6,784) cycles   OK
<set,res> n,<bcdehl(hl)a>.....(  6,912) cycles   OK
<set,res> n,(<ix,iy>+1).......(    448) cycles   OK
<set,res> n,(<ix,iy>-1).......(    448) cycles   OK
ld (<ix,iy>+1),<b,c,d,e>......(  1,024) cycles   OK
ld (<ix,iy>-1),<b,c,d,e>......(  1,024) cycles   OK
ld (<ix,iy>+1),<h,l>..........(    256) cycles   OK
ld (<ix,iy>-1),<h,l>..........(    256) cycles   OK
ld (<ix,iy>+1),a..............(     64) cycles   OK
ld (<ix,iy>-1),a..............(     64) cycles   OK
ld (<bc,de>),a................(     96) cycles   OK
Some failure detected.
```

**Note:**

The following failure is pre-existing and needs further investigation:

`<ini,outi,ind,outd><,r>.......( 65,536) cycles   ERROR **** crc expected:47fff448 found:e3b0d5e0 `




